### PR TITLE
Add individual family page

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,3 +11,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+.timeline-sidebar {
+  background-color: #d9d9d9;
+}

--- a/client/src/pages/Families/FamiliesPage.test.tsx
+++ b/client/src/pages/Families/FamiliesPage.test.tsx
@@ -1,10 +1,24 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
+import { act } from "react-dom/test-utils";
 
 import FamiliesPage from "./FamiliesPages";
 
-test("renders Dashboard page", () => {
+test("renders Family page", () => {
   render(<FamiliesPage />);
-  const textElement = screen.getByText("Families!");
+  const textElement = screen.getByText("Family");
   expect(textElement).toBeInTheDocument();
+});
+
+test("renders confirmation when clicking delete", async () => {
+  render(<FamiliesPage />);
+  const removeMateBtn = screen.getAllByLabelText("delete")[0];
+  await act(async () => {
+    fireEvent.click(removeMateBtn);
+    await waitFor(() =>
+      expect(
+        screen.queryByText("This operation cannot be reversed")
+      ).toBeInTheDocument()
+    );
+  });
 });

--- a/client/src/pages/Families/FamiliesPages.tsx
+++ b/client/src/pages/Families/FamiliesPages.tsx
@@ -1,12 +1,150 @@
-import { Typography } from "antd";
+import { ExclamationCircleOutlined } from "@ant-design/icons";
+import { Col, Modal, Row, Timeline, Typography } from "antd";
 import React from "react";
 
+import NewMateCard from "../../components/NewMateCard/NewMateCard";
+import { NewMateType } from "../types";
+
+const family = "College";
+const syncs: NewMateType[] = [
+  {
+    name: "George Washington",
+    lastSynced: new Date("2021-09-01"),
+    id: 1,
+  },
+  {
+    name: "John Adams",
+    lastSynced: new Date("2021-08-29"),
+    id: 2,
+  },
+  {
+    name: "Thomas Jefferson",
+    lastSynced: new Date("2021-08-13"),
+    id: 3,
+  },
+  {
+    name: "James Madison",
+    lastSynced: new Date("2021-08-13"),
+    id: 4,
+  },
+  {
+    name: "John Adams",
+    lastSynced: new Date("2021-09-13"),
+    id: 5,
+  },
+  {
+    name: "James Madison",
+    lastSynced: new Date("2021-06-09"),
+    id: 6,
+  },
+  {
+    name: "John Quincy Adams",
+    lastSynced: new Date("2021-07-13"),
+    id: 7,
+  },
+  {
+    name: "James Madison",
+    lastSynced: new Date("2021-09-11"),
+    id: 8,
+  },
+  {
+    name: "John Quincy Adams",
+    lastSynced: new Date("2021-04-12"),
+    id: 9,
+  },
+  {
+    name: "Andrew Jackson ",
+    lastSynced: new Date("2021-04-22"),
+    id: 10,
+  },
+  {
+    name: "Martin Van Buren ",
+    lastSynced: new Date("2021-04-22"),
+    id: 11,
+  },
+];
+
+const matesObj = syncs.reduce((prevObj: Record<string, NewMateType>, sync) => {
+  if (
+    !(sync.name in prevObj) ||
+    prevObj[sync.name].lastSynced > sync.lastSynced
+  ) {
+    return { ...prevObj, [sync.name]: sync };
+  }
+  return prevObj;
+}, {});
+
+const { confirm } = Modal;
 const { Title } = Typography;
 
-const FamiliesPage = (): JSX.Element => (
-  <>
-    <Title>Families!</Title>
-  </>
-);
+const FamiliesPage = (): JSX.Element => {
+  const removeMate = (mate: NewMateType) => {
+    confirm({
+      title: `Are you sure you want to delete ${mate.name}?`,
+      icon: <ExclamationCircleOutlined />,
+      content: "This operation cannot be reversed",
+      okText: "Delete",
+      okType: "danger",
+      cancelText: "No",
+      onOk() {
+        // TODO
+        console.log("Delete mate"); // eslint-disable-line no-console
+      },
+    });
+  };
+  return (
+    <>
+      <Row>
+        <Col span={18}>
+          <div
+            style={{
+              backgroundColor: "#F0F2F5",
+              height: "200px",
+              padding: "20px",
+            }}
+          >
+            <Title level={5}>Family</Title>
+            <Title>{family}</Title>
+            <Title level={5}>Syncs: Weekly</Title>
+          </div>
+          <div style={{ backgroundColor: "#F7F8FC", padding: "20px" }}>
+            <Row gutter={[24, 24]}>
+              {Object.values(matesObj).map((mate) => (
+                <Col span={6} key={mate.id}>
+                  <NewMateCard mate={mate} removeMate={removeMate} />
+                </Col>
+              ))}
+            </Row>
+          </div>
+        </Col>
+        <Col span={6} className="timeline-sidebar" style={{ height: "100vh" }}>
+          <Row justify="center">
+            <Col>
+              <Title level={2}>Timeline</Title>
+            </Col>
+          </Row>
+          <Row justify="center">
+            <Col span={20}>
+              <Timeline mode="left" reverse>
+                {syncs
+                  .sort(
+                    (a, b) => a.lastSynced.valueOf() - b.lastSynced.valueOf()
+                  )
+                  .map((sync) => (
+                    <Timeline.Item
+                      key={sync.id}
+                      label={sync.lastSynced.toLocaleDateString()}
+                    >
+                      {sync.name}
+                    </Timeline.Item>
+                  ))}
+              </Timeline>
+            </Col>
+          </Row>
+        </Col>
+      </Row>
+    </>
+  );
+};
 
 export default FamiliesPage;

--- a/client/src/pages/Families/FamiliesPages.tsx
+++ b/client/src/pages/Families/FamiliesPages.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import NewMateCard from "../../components/NewMateCard/NewMateCard";
 import { NewMateType } from "../types";
 
+/* Hardcoded data below */
 const family = "College";
 const syncs: NewMateType[] = [
   {
@@ -73,12 +74,21 @@ const matesObj = syncs.reduce((prevObj: Record<string, NewMateType>, sync) => {
   }
   return prevObj;
 }, {});
+/* Hardcoded data above */
 
 const { confirm } = Modal;
 const { Title } = Typography;
 
+/**
+ * FamiliesPage
+ * @returns
+ */
 const FamiliesPage = (): JSX.Element => {
-  const removeMate = (mate: NewMateType) => {
+  /**
+   * Remove mate from server
+   * @param mate to be removed
+   */
+  const removeMate = (mate: NewMateType): void => {
     confirm({
       title: `Are you sure you want to delete ${mate.name}?`,
       icon: <ExclamationCircleOutlined />,


### PR DESCRIPTION
This PR adds an individual family's page. It's just a frontend mockup with no backend functionality. It has the following information:
- name of family
- sync frequency
- card info of all mates
- timeline of all the recent syncs within the family

Clicking on the delete button pops up a confirmation modal

## Screenshot
<img width="1680" alt="Screen Shot 2021-09-26 at 5 57 16 PM" src="https://user-images.githubusercontent.com/12789302/134825582-68c31066-9f09-407f-bd99-61c967798ca8.png">
<img width="1680" alt="Screen Shot 2021-09-26 at 5 57 30 PM" src="https://user-images.githubusercontent.com/12789302/134825585-d9d10cfd-62f6-4709-b9d6-7c84096c8528.png">

## Bugs / TODO
- Page to view all the families (need discussion on the design)
- fetch / update family information from server