### PR TITLE
fix: Re-work cd script to force pipenv to run in pre-defined virtualenv

### DIFF
--- a/.github/workflows/backendCD.yml
+++ b/.github/workflows/backendCD.yml
@@ -28,6 +28,7 @@ jobs:
             git reset --hard origin/main &&
             git pull origin main &&
             cd server &&
+            source syncm8env/bin/activate &&
             pipenv install --deploy &&
             sudo systemctl restart syncm8.service
           '


### PR DESCRIPTION
Pipenv is currently causing backend cd to fail. Root cause is un-triaged but by running it inside a pre-created virualenv, we will hopefully have a less stochastic deploy target.