### PR TITLE
remove @success-color from craco.config.js

### DIFF
--- a/client/craco.config.js
+++ b/client/craco.config.js
@@ -9,7 +9,6 @@ module.exports = {
           lessOptions: {
             modifyVars: {
               "@primary-color": "#F6A959",
-              "@success-color": "#59A6F6",
               "@body-background": "#F7F8FC",
               "@header-background": "#F0F2F5",
             },


### PR DESCRIPTION
## Changes made
This PR removes `@success-color` from `craco.config.js`. I suspect we're not using it correctly, as `success-color` is primarily used to alert information. However, it very similarly resembles another type of alert (i.e. information), so we should remove this for now.

## Screencapture (if applicable)
### Current
![image](https://user-images.githubusercontent.com/12789302/137635003-2daa6e43-e160-4468-87cb-29014caee504.png)

### After change
![image](https://user-images.githubusercontent.com/12789302/137635121-688eb44c-f0bb-4eac-b1e6-8b939a4c25fc.png)


## Work left to be done
Examine and plan out color theme more broadly: https://antdtheme.com/