### PR TITLE
fix: Explicitly mention env variables in github cd yml

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           python-version: '3.8'
       - name: run migration script
+        env:
+          MONGO_USER: ${{ secrets.MONGO_USER  }}
+          MONGO_PASSWORD: ${{ secrets.MONGO_PASSWORD  }}
+          MONGO_HOST: ${{ secrets.MONGO_HOST  }}
+
         run: |
           cd server
           pip install pipenv


### PR DESCRIPTION
## Changes made
Mention env variables explicitly in order to attempt to fix cd problems.
Nektos/act may not be a perfect copy of the environment that github actions provides.

## Screencapture (if applicable)


## Work left to be done
