### PR TITLE
[feat] url maintenance

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
     "import/no-extraneous-dependencies": "off",
     "arrow-body-style": ["error", "as-needed"],
     "no-console": ["warn", { allow: ["warn", "error"] }],
+    "no-debugger": "warn",
   },
   ignorePatterns: [".eslintrc.js", "craco.config.js", "src/setupTests.js"],
 };

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -38,6 +38,7 @@
         "@types/react-router-dom": "^5.1.9",
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
+        "axios-mock-adapter": "^1.20.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-airbnb-typescript": "^14.0.0",
@@ -4828,6 +4829,43 @@
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
         "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/axios-mock-adapter": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz",
+      "integrity": "sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-blob": "^2.1.0",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.9.0"
+      }
+    },
+    "node_modules/axios-mock-adapter/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axobject-query": {
@@ -10967,6 +11005,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-boolean-object": {
@@ -26813,6 +26863,25 @@
         "follow-redirects": "^1.14.0"
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz",
+      "integrity": "sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "is-blob": "^2.1.0",
+        "is-buffer": "^2.0.5"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+          "dev": true
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -31557,6 +31626,12 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
+    },
+    "is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "dev": true
     },
     "is-boolean-object": {
       "version": "1.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -57,6 +57,7 @@
     "@types/react-router-dom": "^5.1.9",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
+    "axios-mock-adapter": "^1.20.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-typescript": "^14.0.0",

--- a/client/public/index.css
+++ b/client/public/index.css
@@ -1,0 +1,19 @@
+.svg-loader {
+  animation: spin 1s linear infinite;
+  margin: auto;
+}
+.div-loader {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -15,6 +15,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="stylesheet" href="index.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -28,7 +29,15 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <div id="root">
+      <div class="div-loader">
+        <svg class="svg-loader" viewBox="0 0 1024 1024" width="10em" height="10em">
+          <path fill="#F6A959"
+            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+          />
+        </svg>
+      </div>
+    </div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/client/src/components/LoadingSpinner/LoadingSpinner.css
+++ b/client/src/components/LoadingSpinner/LoadingSpinner.css
@@ -1,0 +1,11 @@
+/**
+ * Same as .div-loader in index.css
+ * Cannot use that as style gets overwritten
+ */
+.spin-center {
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/client/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/client/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,0 +1,19 @@
+import "./LoadingSpinner.css";
+
+import { LoadingOutlined } from "@ant-design/icons";
+import { Spin } from "antd";
+import React from "react";
+
+/**
+ * Loading Spinner component
+ * @returns JSX.Element
+ */
+const LoadingSpinner = (): JSX.Element => (
+  <Spin
+    className="spin-center"
+    size="large"
+    indicator={<LoadingOutlined style={{ fontSize: 180 }} />}
+  />
+);
+
+export default LoadingSpinner;

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import { Redirect, Route } from "react-router";
+import { Redirect, Route, useLocation } from "react-router";
+
+import { LocationState } from "../../pages/types";
 
 type ProtectedRoutesPropTypes = {
   children: React.ReactNode;
@@ -8,17 +10,25 @@ type ProtectedRoutesPropTypes = {
   exact?: boolean | undefined;
 };
 
-const isTesting = () => process.env.JEST_WORKER_ID !== undefined;
 const ProtectedRoute = ({
   children,
   loggedIn,
   path,
   exact,
-}: ProtectedRoutesPropTypes): JSX.Element => (
-  <Route exact={exact} path={path}>
-    {loggedIn || isTesting() ? children : <Redirect to="/login" />}
-  </Route>
-);
+}: ProtectedRoutesPropTypes): JSX.Element => {
+  const location = useLocation<LocationState>();
+  return (
+    <Route exact={exact} path={path}>
+      {loggedIn ? (
+        children
+      ) : (
+        <Redirect
+          to={{ pathname: "/login", state: { prevPath: location.pathname } }}
+        />
+      )}
+    </Route>
+  );
+};
 ProtectedRoute.defaultProps = { exact: false };
 
 export default ProtectedRoute;

--- a/client/src/pages/App/App.test.tsx
+++ b/client/src/pages/App/App.test.tsx
@@ -1,13 +1,14 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import axios from "axios";
-import MockAdopter from "axios-mock-adapter";
+import MockAdapter from "axios-mock-adapter";
 import { createMemoryHistory } from "history";
 import React from "react";
 import { Router } from "react-router-dom";
 
+import { name as mockName } from "../Dashboard/mockData";
 import App from "./App";
 
-const mock = new MockAdopter(axios);
+const mock = new MockAdapter(axios);
 
 beforeEach(() => {
   mock.onGet("/isLoggedIn").reply(200, { isLoggedIn: true });
@@ -63,7 +64,7 @@ test("routes Dashboard if logged in", async () => {
   );
   await waitFor(() => expect(history.location.pathname).toBe("/"));
   await waitFor(() =>
-    expect(screen.queryByText("Hi, Paul")).toBeInTheDocument()
+    expect(screen.queryByText(`Hi, ${mockName}`)).toBeInTheDocument()
   );
 });
 

--- a/client/src/pages/App/App.tsx
+++ b/client/src/pages/App/App.tsx
@@ -14,25 +14,31 @@ import LoginPage from "../Login/LoginPage";
 import MatesPage from "../Mates/MatesPage";
 import NewMatesPage from "../NewMates/NewMatesPage";
 
-const App = (): JSX.Element => {
+/**
+ * Main App page
+ * @returns JSX.Element or null
+ */
+const App = (): JSX.Element | null => {
   const [loggedIn, setLoggedIn] = useState(false);
+  const [checkedLoggedIn, setCheckedLoggedIn] = useState(false);
 
   useEffect(() => {
     axios
       .get<IsLoggedInResponse>(isLoggedInPath)
       .then((res) => {
-        let resLoggedIn = false;
-        if ("isLoggedIn" in res.data) {
-          resLoggedIn = res.data.isLoggedIn;
-        }
+        const resLoggedIn = res.data?.isLoggedIn ?? false;
         if (loggedIn !== resLoggedIn) {
           setLoggedIn(resLoggedIn);
         }
       })
-      .catch((err) => console.error(err));
+      .catch((err) => console.error(err))
+      .finally(() => setCheckedLoggedIn(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  if (!checkedLoggedIn) {
+    return null;
+  }
   return (
     <>
       <Header />

--- a/client/src/pages/App/App.tsx
+++ b/client/src/pages/App/App.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from "react";
 import { Route, Switch } from "react-router-dom";
 
 import { isLoggedInPath, IsLoggedInResponse } from "../../api";
+import LoadingSpinner from "../../components/LoadingSpinner/LoadingSpinner";
 import ProtectedRoute from "../../components/ProtectedRoute/ProtectedRoute";
 import AssignMatesPage from "../AssignMates/AssignMatesPage";
 import DashboardPage from "../Dashboard/DashboardPage";
@@ -15,30 +16,48 @@ import MatesPage from "../Mates/MatesPage";
 import NewMatesPage from "../NewMates/NewMatesPage";
 
 /**
- * Main App page
- * @returns JSX.Element or null
+ * Logged In Status
  */
-const App = (): JSX.Element | null => {
-  const [loggedIn, setLoggedIn] = useState(false);
-  const [checkedLoggedIn, setCheckedLoggedIn] = useState(false);
+enum LoggedInStatus {
+  LOGGED_IN = "LoggedIn",
+  LOGGED_OUT = "LoggedOut",
+  WAITING = "Waiting",
+}
+/**
+ * Main App page
+ * @returns JSX.Element
+ */
+const App = (): JSX.Element => {
+  const [loggedInStatus, setLoggedInStatus] = useState(LoggedInStatus.WAITING);
 
   useEffect(() => {
     axios
       .get<IsLoggedInResponse>(isLoggedInPath)
       .then((res) => {
-        const resLoggedIn = res.data?.isLoggedIn ?? false;
-        if (loggedIn !== resLoggedIn) {
-          setLoggedIn(resLoggedIn);
+        const resStatus = res.data?.isLoggedIn
+          ? LoggedInStatus.LOGGED_IN
+          : LoggedInStatus.LOGGED_OUT;
+        if (loggedInStatus !== resStatus) {
+          setLoggedInStatus(resStatus);
         }
       })
-      .catch((err) => console.error(err))
-      .finally(() => setCheckedLoggedIn(true));
+      .catch((err) => {
+        console.error(err);
+        setLoggedInStatus(LoggedInStatus.LOGGED_OUT);
+      });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  if (!checkedLoggedIn) {
-    return null;
+  const setLoggedIn = (value: boolean) => {
+    setLoggedInStatus(
+      value ? LoggedInStatus.LOGGED_IN : LoggedInStatus.LOGGED_OUT
+    );
+  };
+
+  if (loggedInStatus === LoggedInStatus.WAITING) {
+    return <LoadingSpinner />;
   }
+  const loggedIn = loggedInStatus === LoggedInStatus.LOGGED_IN;
   return (
     <>
       <Header />

--- a/client/src/pages/Login/LoginPage.test.tsx
+++ b/client/src/pages/Login/LoginPage.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import React from "react";
+import { Route, Router, Switch } from "react-router-dom";
+
+import LoginPage from "./LoginPage";
+
+test("routes to prevPath if loggedIn and prevPath is set", async () => {
+  const prevPath = "/somewhereOverTheRainbow";
+  const history = createMemoryHistory();
+  history.replace("/login", { prevPath });
+  render(
+    <Router history={history}>
+      <Switch>
+        <Route path="/login">
+          <LoginPage loggedIn setLoggedIn={jest.fn()} />
+        </Route>
+      </Switch>
+    </Router>
+  );
+  await waitFor(() => expect(history.location.pathname).toBe(prevPath));
+});
+
+test("routes to / if loggedIn and prevPath is not set", async () => {
+  const history = createMemoryHistory({ initialEntries: ["/login"] });
+  render(
+    <Router history={history}>
+      <Switch>
+        <Route path="/login">
+          <LoginPage loggedIn setLoggedIn={jest.fn()} />
+        </Route>
+      </Switch>
+    </Router>
+  );
+  await waitFor(() => expect(history.location.pathname).toBe("/"));
+});
+
+test("renders login button if not loggedIn", async () => {
+  jest.spyOn(console, "error").mockImplementation(() => {}); // suppresses the expected console.error
+
+  const history = createMemoryHistory({ initialEntries: ["/login"] });
+  render(
+    <Router history={history}>
+      <Switch>
+        <Route path="/login">
+          <LoginPage loggedIn={false} setLoggedIn={jest.fn()} />
+        </Route>
+      </Switch>
+    </Router>
+  );
+  const loginBtn = screen.getByText("Login with Google");
+  await waitFor(() => expect(loginBtn).toBeInTheDocument());
+  fireEvent.click(loginBtn);
+});

--- a/client/src/pages/Login/LoginPage.tsx
+++ b/client/src/pages/Login/LoginPage.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { useHistory, useLocation } from "react-router-dom";
 
 import { loginPath, LoginResponse } from "../../api";
+import LoadingSpinner from "../../components/LoadingSpinner/LoadingSpinner";
 import { LocationState } from "../types";
 
 const { Title } = Typography;
@@ -35,10 +36,7 @@ const doLogin = () => {
   )}`;
 };
 
-const LoginPage = ({
-  loggedIn,
-  setLoggedIn,
-}: LoginPageProps): JSX.Element | null => {
+const LoginPage = ({ loggedIn, setLoggedIn }: LoginPageProps): JSX.Element => {
   const history = useHistory();
   const location = useLocation<LocationState>();
 
@@ -68,7 +66,7 @@ const LoginPage = ({
   if (loggedIn) {
     const prevPath = location.state?.prevPath ?? "/";
     history.replace(prevPath);
-    return null;
+    return <LoadingSpinner />;
   }
   return (
     <>

--- a/client/src/pages/Login/LoginPage.tsx
+++ b/client/src/pages/Login/LoginPage.tsx
@@ -2,9 +2,10 @@ import { Button, notification, Typography } from "antd";
 import axios from "axios";
 import { parse, stringify } from "querystring";
 import React from "react";
-import { Redirect } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 
 import { loginPath, LoginResponse } from "../../api";
+import { LocationState } from "../types";
 
 const { Title } = Typography;
 
@@ -34,7 +35,13 @@ const doLogin = () => {
   )}`;
 };
 
-const LoginPage = ({ loggedIn, setLoggedIn }: LoginPageProps): JSX.Element => {
+const LoginPage = ({
+  loggedIn,
+  setLoggedIn,
+}: LoginPageProps): JSX.Element | null => {
+  const history = useHistory();
+  const location = useLocation<LocationState>();
+
   const checkloginCallback = () => {
     // window.location.hash keeps the hash, part so we chop it off with substr
     const parsedParams = parse(window.location.hash.substr(1));
@@ -57,8 +64,12 @@ const LoginPage = ({ loggedIn, setLoggedIn }: LoginPageProps): JSX.Element => {
 
   checkloginCallback();
 
-  // Redirect if authentication is done:
-  if (loggedIn) return <Redirect to="/" />;
+  // Redirect if authentication is done
+  if (loggedIn) {
+    const prevPath = location.state?.prevPath ?? "/";
+    history.replace(prevPath);
+    return null;
+  }
   return (
     <>
       <Title>Login</Title>

--- a/client/src/pages/types.ts
+++ b/client/src/pages/types.ts
@@ -32,3 +32,7 @@ export type UpcomingSyncType = {
   lastSynced: Date;
   upcomingSync: Date;
 };
+
+export type LocationState = {
+  prevPath: string;
+};


### PR DESCRIPTION
## Changes made
This PR maintains the user's path URL when checking for logged-in status.
- Previously, whenever user first load a page with a path (e.g. `/mates`), the app redirects them to login page and then to the dashboard after verifying their auth.
- If they are logged out, it still leads user back to dashboard.


## Screencapture (if applicable)

### Before
https://user-images.githubusercontent.com/12789302/139516922-b76f9388-1c31-4422-9d3d-c83ab1429532.mov

### After
https://user-images.githubusercontent.com/12789302/139516930-41ecfd63-1ff0-4b5b-8136-744b736d6347.mov

### After (logged out user)
https://user-images.githubusercontent.com/12789302/139516938-04c568b4-86c5-466f-a0eb-8d0fe862cd3e.mov

### Loader (feature added after previous screen captures)
https://user-images.githubusercontent.com/12789302/139540719-85c15166-edea-4217-95d5-678af42a442a.mov

## Work left to be done
- If a user is logged out, the site routes them to Dashboard after logging in. Maintaining url for logged out user is harder since oAuth makes the user go to `accounts.google.com/...` and then back to our app. Maintaining url for this case would require storing the previous path somewhere locally.