### PR TITLE
[feat] Add family_ids and starter families

### DIFF
--- a/server/Pipfile
+++ b/server/Pipfile
@@ -20,10 +20,13 @@ flask-mongoengine = "*"
 mongoengine = "*"
 
 [dev-packages]
-pytest = "*"
-pre-commit = "*"
-mypy = "*"
+black = "*"
+flake8 = "*"
 mongomock = "*"
+mypy = "*"
+pre-commit = "*"
+pydocstyle = "*"
+pytest = "*"
 
 [requires]
 python_version = "3.8"

--- a/server/src/gql/resolver.py
+++ b/server/src/gql/resolver.py
@@ -8,7 +8,8 @@ from flask_login import current_user
 from src.gql.graphql import NewMatesInput
 from src.model.family import Family
 from src.model.mate import Mate
-from src.model.user import UNASSIGNED_FAMILY_INTERVAL, User
+from src.model.user import User
+from src.types.new_family import UNASSIGNED_FAMILY
 
 oid_scalar = ScalarType("oid")
 
@@ -40,7 +41,7 @@ def resolve_add_new_mates(
     family = Family.lookup_family(user.unassigned_family_id)
     if not family:
         family_error, family = Family.add_new_family(
-            "Unassigned", UNASSIGNED_FAMILY_INTERVAL
+            UNASSIGNED_FAMILY.name, UNASSIGNED_FAMILY.sync_interval_days
         )
         if family_error or not family:
             raise Exception("Family not found and cannot be created")

--- a/server/src/types/new_family.py
+++ b/server/src/types/new_family.py
@@ -1,0 +1,22 @@
+"""Type NewFamily."""
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class NewFamily:
+    """Class to represent a new Family."""
+
+    name: str
+    sync_interval_days: int
+
+
+UNASSIGNED_FAMILY = NewFamily("Unassigned", 3650)  # Auto-assigned to 10-year interval
+
+
+STARTER_FAMILIES: List[NewFamily] = [
+    NewFamily("Biweekly", 14),
+    NewFamily("Monthly", 28),
+    NewFamily("Quarterly", 91),
+    NewFamily("Yearly", 365),
+]


### PR DESCRIPTION
## Changes made
- This PR adds `family_ids` to `User` model, which holds the id's of all the families belonging to the user.
- Also add 4 starter families, which the user may alter afterward:
  - Biweekly (every 14 days)
  - Monthly (every 28 days)
  - Quarterly (every 91 days)
  - Yearly (every 365 days)

### Chain PRs:
1. add attribute `family_ids` [THIS] #58
2. migrate #59 

## Screencapture (if applicable)


## Work left to be done
