### PR TITLE
[fix] Change foreign key attributes to LazyReferenceField

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -90,7 +90,7 @@ runJstest(){
 # Run precommit inside container
 runPrecommit(){
     findBackendContainerId container_id
-    cmd="docker exec -it -w /home/worker/app/ "$container_id" pre-commit "$*
+    cmd="docker exec -t -w /home/worker/app/ "$container_id" pre-commit "$*
     echo $cmd
     exec $cmd
 }

--- a/bin/dev
+++ b/bin/dev
@@ -68,7 +68,7 @@ runWebpack(){
 # Run pytest
 runPytest(){
     findBackendContainerId container_id
-    cmd="docker exec -t "$container_id" pytest "$*
+    cmd="docker exec -it "$container_id" pytest "$*
     echo $cmd
     exec $cmd
 }
@@ -76,7 +76,7 @@ runPytest(){
 # Run migrate
 runMigrate(){
     findBackendContainerId container_id
-    cmd="docker exec -t "$container_id" pipenv run python3 -m src.db.runner"
+    cmd="docker exec -it "$container_id" pipenv run python3 -m src.db.runner"
     echo $cmd
     exec $cmd
 }
@@ -90,7 +90,7 @@ runJstest(){
 # Run precommit inside container
 runPrecommit(){
     findBackendContainerId container_id
-    cmd="docker exec -t -w /home/worker/app/ "$container_id" pre-commit "$*
+    cmd="docker exec -it -w /home/worker/app/ "$container_id" pre-commit "$*
     echo $cmd
     exec $cmd
 }

--- a/server/src/model/family.py
+++ b/server/src/model/family.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 from typing import Optional, Tuple, cast
 
-from mongoengine import Document, IntField, ListField, ObjectIdField, StringField
+from mongoengine import Document, IntField, LazyReferenceField, ListField, StringField
+from src.model.mate import Mate
 from src.utils.error import AppError, ErrorCode, error_bounded
 
 
@@ -14,7 +15,7 @@ class Family(Document):
 
     sync_interval_days = IntField(required=True)
     name = StringField(required=True)
-    mate_ids = ListField(ObjectIdField(), default=list)
+    mate_ids = ListField(LazyReferenceField(Mate), default=list)
 
     meta = {"collection": "families", "strict": False}
 

--- a/server/src/model/family.py
+++ b/server/src/model/family.py
@@ -3,7 +3,7 @@
 # https://www.python.org/dev/peps/pep-0563/
 from __future__ import annotations
 
-from typing import Optional, Tuple, cast, List
+from typing import List, Optional, Tuple, cast
 
 from mongoengine import Document, IntField, LazyReferenceField, ListField, StringField
 from src.model.mate import Mate

--- a/server/src/model/family.py
+++ b/server/src/model/family.py
@@ -3,7 +3,7 @@
 # https://www.python.org/dev/peps/pep-0563/
 from __future__ import annotations
 
-from typing import Optional, Tuple, cast
+from typing import Optional, Tuple, cast, List
 
 from mongoengine import Document, IntField, LazyReferenceField, ListField, StringField
 from src.model.mate import Mate
@@ -18,6 +18,11 @@ class Family(Document):
     mate_ids = ListField(LazyReferenceField(Mate), default=list)
 
     meta = {"collection": "families", "strict": False}
+
+    @property
+    def mates(self) -> List[Mate]:
+        """Fetch object for mate_ids."""
+        return [mate.fetch() for mate in self.mate_ids]
 
     def get_id(self) -> str:
         """Return string version of mongo oid."""

--- a/server/src/model/mate.py
+++ b/server/src/model/mate.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import List, Optional, Tuple, cast
 
 from dateutil.parser import isoparse  # type: ignore
-from mongoengine import Document, ListField, ObjectIdField, StringField
+from mongoengine import Document, LazyReferenceField, ListField, StringField
 from src.gql.graphql import NewMatesInput
 from src.model.sync import Sync
 from src.utils.error import AppError, ErrorCode, error_bounded
@@ -17,7 +17,7 @@ class Mate(Document):
     """Mate model class."""
 
     name = StringField(required=True, max_length=100)
-    sync_ids = ListField(ObjectIdField(), default=list)
+    sync_ids = ListField(LazyReferenceField(Sync), default=list)
     meta = {"collection": "mates", "strict": False}
 
     def get_id(self) -> str:

--- a/server/src/model/mate.py
+++ b/server/src/model/mate.py
@@ -20,6 +20,11 @@ class Mate(Document):
     sync_ids = ListField(LazyReferenceField(Sync), default=list)
     meta = {"collection": "mates", "strict": False}
 
+    @property
+    def syncs(self) -> List[Sync]:
+        """Fetch object for sync_ids."""
+        return [sync.fetch() for sync in self.sync_ids]
+
     def get_id(self) -> str:
         """Return string version of mongo oid."""
         return str(self.id)

--- a/server/src/model/user.py
+++ b/server/src/model/user.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Tuple, cast
 
 from bson.objectid import ObjectId
 from flask_login import UserMixin
-from mongoengine import Document, ListField, ObjectIdField, StringField
+from mongoengine import Document, LazyReferenceField, ListField, StringField
 from src.clients.google import get_user_info
 from src.model.family import Family
 from src.types.new_family import STARTER_FAMILIES, UNASSIGNED_FAMILY
@@ -21,9 +21,9 @@ class User(Document, UserMixin):
     google_id = StringField()
     google_token = StringField()
     picture_url = StringField()
-    unassigned_family_id = ObjectIdField(required=True)
+    unassigned_family_id = LazyReferenceField(Family, required=True)
     email = StringField(required=True, max_length=320)
-    family_ids = ListField(ObjectIdField(), required=True, default=list)
+    family_ids = ListField(LazyReferenceField(Family), required=True, default=list)
     meta = {"collection": "users", "strict": False}
 
     def get_id(self) -> str:

--- a/server/src/model/user.py
+++ b/server/src/model/user.py
@@ -26,6 +26,16 @@ class User(Document, UserMixin):
     family_ids = ListField(LazyReferenceField(Family), required=True, default=list)
     meta = {"collection": "users", "strict": False}
 
+    @property
+    def unassigned_family(self) -> Family:
+        """Fetch object for unassigned_family_id."""
+        return self.unassigned_family_id.fetch()  # type: ignore
+
+    @property
+    def families(self) -> List[Family]:
+        """Fetch object for family_ids."""
+        return [family_id.fetch() for family_id in self.family_ids]
+
     def get_id(self) -> str:
         """Return string version of mongo oid."""
         return str(self.id)

--- a/server/tests/model/test_family.py
+++ b/server/tests/model/test_family.py
@@ -1,14 +1,14 @@
 """Test the family model."""
 
-from unittest import mock
 from typing import List
+from unittest import mock
 
 import pytest
-from src.model.mate import Mate
-from src.model.family import Family
-from src.utils.error import ErrorCode
-from tests.model.test_mate import mateSteve, mateJobs
 from src.gql.graphql import NewMatesInput
+from src.model.family import Family
+from src.model.mate import Mate
+from src.utils.error import ErrorCode
+from tests.model.test_mate import mateJobs, mateSteve
 
 
 @pytest.mark.usefixtures("db_connection")

--- a/server/tests/model/test_mate.py
+++ b/server/tests/model/test_mate.py
@@ -2,9 +2,11 @@
 
 from typing import List
 from unittest import mock
+from datetime import datetime
 
 import pytest
 from pytest_mock import MockerFixture
+from src.model.sync import Sync
 from src.gql.graphql import NewMatesInput
 from src.model.mate import Mate
 from src.utils.error import AppError, ErrorCode
@@ -73,3 +75,21 @@ def test_bulk_insert_fail() -> None:
     assert error
     assert error.status_code == ErrorCode.MONGO_ERROR
     assert error.error_details == "Mongo error when bulk adding new mates"
+
+
+@pytest.mark.usefixtures("db_connection")
+def test_mate_properties() -> None:
+    """Test LazyReferenceField properties."""
+    new_mates: List[NewMatesInput] = [mateSteve, mateJobs]
+    error, mates = Mate.bulk_insert_new_mates(new_mates)
+    assert mates
+    mate = mates[0]
+
+    sync0_err, sync0 = Sync.add_new_sync(datetime.now(), "zero", "details")
+    sync1_err, sync1 = Sync.add_new_sync(datetime.now(), "one", "details")
+    assert sync0 and sync1
+
+    mate.sync_ids = [sync0.id, sync1.id]
+    mate.save()
+    assert len(mate.syncs) == len(mate.sync_ids)
+    assert type(mate.syncs[0]) == Sync

--- a/server/tests/model/test_mate.py
+++ b/server/tests/model/test_mate.py
@@ -1,14 +1,14 @@
 """Test the mate model."""
 
+from datetime import datetime
 from typing import List
 from unittest import mock
-from datetime import datetime
 
 import pytest
 from pytest_mock import MockerFixture
-from src.model.sync import Sync
 from src.gql.graphql import NewMatesInput
 from src.model.mate import Mate
+from src.model.sync import Sync
 from src.utils.error import AppError, ErrorCode
 
 mateSteve: NewMatesInput = {"name": "Steve", "lastSynced": "2021-10-23T20:42:06.112Z"}

--- a/server/tests/model/test_user.py
+++ b/server/tests/model/test_user.py
@@ -100,12 +100,12 @@ def test_get_id(mocker: MockerFixture) -> None:
 def test_unassigned_family_id(mocker: MockerFixture) -> None:
     """Test unassigned_family_id was created and populated."""
     user = add_mock_user(mocker, userAlbert)
-    family_id = user.unassigned_family_id
-    assert family_id
-
-    family = Family.lookup_family(family_id)
+    family = user.unassigned_family_id
     assert family
-    assert family.get_id() == str(family_id)
+
+    family = Family.lookup_family(family.id)
+    assert family
+    assert family.get_id() == str(family.id)
     assert family.name == UNASSIGNED_FAMILY.name
     assert family.sync_interval_days == UNASSIGNED_FAMILY.sync_interval_days
 
@@ -119,12 +119,11 @@ def test_starter_family_ids(mocker: MockerFixture) -> None:
     assert len(family_ids) == len(STARTER_FAMILIES) + 1  # account for unassigned family
 
     found_unassigned_family = False
-    for family_id in family_ids:
-        family = Family.lookup_family(family_id)
-        assert family
-        assert family.get_id() == str(family_id)
+    for family_ref in family_ids:
+        family = family_ref.fetch()
+        assert family.get_id() == str(family.id)
 
-        if family.id == user.unassigned_family_id:
+        if family == user.unassigned_family_id:
             found_unassigned_family = True
             continue
 

--- a/server/tests/model/test_user.py
+++ b/server/tests/model/test_user.py
@@ -102,7 +102,6 @@ def test_unassigned_family_id(mocker: MockerFixture) -> None:
     user = add_mock_user(mocker, userAlbert)
     family = user.unassigned_family
     assert family
-    assert family.get_id() == str(family.id)
     assert family.name == UNASSIGNED_FAMILY.name
     assert family.sync_interval_days == UNASSIGNED_FAMILY.sync_interval_days
 

--- a/server/tests/model/test_user.py
+++ b/server/tests/model/test_user.py
@@ -4,7 +4,6 @@ from typing import Dict
 
 import pytest
 from pytest_mock import MockerFixture
-from src.model.family import Family
 from src.model.user import User
 from src.types.new_family import STARTER_FAMILIES, UNASSIGNED_FAMILY
 
@@ -100,7 +99,7 @@ def test_get_id(mocker: MockerFixture) -> None:
 def test_unassigned_family_id(mocker: MockerFixture) -> None:
     """Test unassigned_family_id was created and populated."""
     user = add_mock_user(mocker, userAlbert)
-    family = user.unassigned_family_id
+    family = user.unassigned_family_id.fetch()
     assert family
     assert family.get_id() == str(family.id)
     assert family.name == UNASSIGNED_FAMILY.name

--- a/server/tests/model/test_user.py
+++ b/server/tests/model/test_user.py
@@ -102,9 +102,6 @@ def test_unassigned_family_id(mocker: MockerFixture) -> None:
     user = add_mock_user(mocker, userAlbert)
     family = user.unassigned_family_id
     assert family
-
-    family = Family.lookup_family(family.id)
-    assert family
     assert family.get_id() == str(family.id)
     assert family.name == UNASSIGNED_FAMILY.name
     assert family.sync_interval_days == UNASSIGNED_FAMILY.sync_interval_days

--- a/server/tests/model/test_user.py
+++ b/server/tests/model/test_user.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 import pytest
 from pytest_mock import MockerFixture
+from src.model.family import Family
 from src.model.user import User
 from src.types.new_family import STARTER_FAMILIES, UNASSIGNED_FAMILY
 
@@ -99,7 +100,7 @@ def test_get_id(mocker: MockerFixture) -> None:
 def test_unassigned_family_id(mocker: MockerFixture) -> None:
     """Test unassigned_family_id was created and populated."""
     user = add_mock_user(mocker, userAlbert)
-    family = user.unassigned_family_id.fetch()
+    family = user.unassigned_family
     assert family
     assert family.get_id() == str(family.id)
     assert family.name == UNASSIGNED_FAMILY.name
@@ -115,10 +116,7 @@ def test_starter_family_ids(mocker: MockerFixture) -> None:
     assert len(family_ids) == len(STARTER_FAMILIES) + 1  # account for unassigned family
 
     found_unassigned_family = False
-    for family_ref in family_ids:
-        family = family_ref.fetch()
-        assert family.get_id() == str(family.id)
-
+    for family in user.families:
         if family == user.unassigned_family_id:
             found_unassigned_family = True
             continue
@@ -134,3 +132,13 @@ def test_starter_family_ids(mocker: MockerFixture) -> None:
         )
         assert starter_family
     assert found_unassigned_family
+
+
+@pytest.mark.usefixtures("db_connection")
+def test_user_properties(mocker: MockerFixture) -> None:
+    """Test LazyReferenceField properties."""
+    user = add_mock_user(mocker, userAlbert)
+    assert type(user.unassigned_family) == Family
+
+    assert type(user.families) == list
+    assert type(user.families[0]) == Family


### PR DESCRIPTION
## Changes made
- This PR changes the attribute types of foreign keys in MongoDB from `ObjectId` to `LazyReferenceField`.
  - This lets MongoEngine auto-fetch the reference objects of the foreign keys without querying ourselves (which will get bloated real fast with our nested hierarchy).
  - ref: https://docs.mongoengine.org/apireference.html#mongoengine.fields.LazyReferenceField
- NB: Lazy Reference only has access to `_id`. Need to call `fetch()` in order to retrieve other fields of the object.

## Screencapture (if applicable)


## Testing
- [x] End-to-End
Ensure that current data in DB returns `LazyReference` with no migration.
<img width="1106" alt="Screen Shot 2021-11-09 at 10 37 27 PM" src="https://user-images.githubusercontent.com/12789302/141046561-bcbf6def-8bc2-4013-a7af-2353bb6c5c04.png">


## Work left to be done
