### PR TITLE
[chore] Make all pr actions work for ghstack. (#85)

### DIFF
--- a/.github/workflows/prTitle.yml
+++ b/.github/workflows/prTitle.yml
@@ -3,7 +3,6 @@ name: pr-title
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    branches: [ main, dev ]
 
 jobs:
   pr-title-check:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,6 @@ name: pre-commit
 
 on:
   pull_request:
-    branches: [ main, dev ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Changes made
Remove stipulation that prTitle and pre-commit must be run on main or dev.

## Screencapture (if applicable)

## Testing
- [ ] End-to-End

## Work left to be done

[ghstack-poisoned]

## Changes made


## Screencapture (if applicable)


## Testing
- [ ] End-to-End


## Work left to be done
