### PR TITLE
[feat] Move secrets into AWS Parameter Store

### DIFF
--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -9,10 +9,21 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 ENV PIPENV_VENV_IN_PROJECT 1
 ENV FLASK_APP 'server:app'
-WORKDIR /home/worker/app/server/
 
 # install pipenv
+WORKDIR /home/worker/app/server/
 RUN pip install pipenv
+WORKDIR /home/worker/app/
+
 ENV PATH /home/worker/app/server/.venv/bin:$PATH
+
+# app specific env
+ENV FLASK_ENV development
+ENV PRE_COMMIT_HOME /home/worker/app/.pre-commit
+ENV APP_SECRET_KEY b\xaeX\xe6x5\x02/\xcb\xad\xa3\x8f\x97D\xab\xbe/!\xf2\xe4H\x1b\xdb\xdcv
+ENV GOOGLE_CLIENT_ID 711095332609-rfg1tm319vhrs7i1tf1ubclo99srmc08.apps.googleusercontent.com
+ENV MONGO_HOST mongodb
+ENV MONGO_USER user
+ENV MONGO_PASSWORD pass
 
 ENTRYPOINT ["bash"]

--- a/README.md
+++ b/README.md
@@ -13,19 +13,20 @@
 
 1. Install Latest [Docker](https://docs.docker.com/get-docker/)
 2. Install Latest [Node/npm](https://nodejs.org/en/download/)
-3. Set up the git hooks.
+3. Install [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+4. Set up the git hooks.
 ```shell
 bin/dev setup
 ```
-4. Start python and mongo containers.
+5. Start python and mongo containers.
 ```shell
 bin/dev up
 ```
-5. Install python dependencies in the container. (You will need to do this every time new python dependencies are added.)
+6. Install python dependencies in the container. (You will need to do this every time new python dependencies are added.)
 ```shell
 bin/dev py-req
 ```
-6.  Install Client dependencies. (You will need to do this every time new npm dependencies are added.)
+7.  Install Client dependencies. (You will need to do this every time new npm dependencies are added.)
 ```shell
 bin/dev client-req
 ```

--- a/bin/dev
+++ b/bin/dev
@@ -117,6 +117,7 @@ runSetup(){
 
 # Pull images from aws ECR
 runPull(){
+    bin/util logAndRun "bin/infra pull-env"
     bin/util logAndRun "bin/infra pull"
 }
 

--- a/bin/infra
+++ b/bin/infra
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 AWS_KEYS=(AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION)
+EXTERNAL_KEYS=(DEV_SENDGRID_API_KEY)
 DEV_ECR_REPO="public.ecr.aws/a5f0m6q3/syncm8_dev"
 
 # Read value for specified key fron server/dev.env
@@ -46,6 +47,32 @@ dockerBuild(){
     bin/util logAndRun "docker build --pull --rm -t $DEV_ECR_REPO - < Dockerfile_dev"
 }
 
+# Pulls secrets from AWS Parameter Store
+pullEnv(){
+    # load aws env for authentication to parameter store
+    addAWSToEnv
+
+    # create new file
+    echo "" > new.dev.env
+
+    # copy aws keys from dev.env to new.dev.env
+    for key in ${AWS_KEYS[@]}; do
+        getKeyValFromDevEnv $key keyValPair
+        echo $keyValPair >> new.dev.env
+    done
+
+    # acquire keys from aws parameter store
+    for ac in ${EXTERNAL_KEYS[@]}; do
+        ret=$(aws ssm get-parameter --name $ac)
+        value=$(echo $ret | grep -Po '"Value":.*?[^\\]",'| cut -d \" -f4)
+        key=$(echo $ac| cut -d _ -f2-)
+        echo $key=$value >> new.dev.env
+    done
+
+    # replace contents of dev.env with new.dev.env
+    mv new.dev.env server/dev.env
+}
+
 # Print help message
 printHelp(){
     echo "Usage:  bin/infra COMMAND
@@ -56,6 +83,7 @@ Commands:
   build       Build dev image.
   login       Authenticate docker with aws ecr.
   pull        Pull image from aws ecr.
+  pull-env    Pulls secrets from AWS Parameter Store
   push        Push dev image to aws ecr.
                   N.b. Must be authenticated with ecr."
 }
@@ -72,6 +100,9 @@ case $op in
         ;;
     pull)
         dockerPull
+        ;;
+    pull-env)
+        pullEnv
         ;;
     push)
         dockerPush

--- a/server/src/clients/google.py
+++ b/server/src/clients/google.py
@@ -37,7 +37,8 @@ def is_google_token_valid(
     (NB: the htto and http2 parameters are only used during testing - if you can figure
     out a better way to make the tests work, go ahead and remove them)
     """
-    with build("oauth2", "v2", http=http) as service:
+    creds = Credentials(token) if token else None
+    with build("oauth2", "v2", credentials=creds, http=http) as service:
         token_info_request = service.tokeninfo(access_token=token)
         token_info = token_info_request.execute(http=http2)
 

--- a/server/tests/clients/test_google.py
+++ b/server/tests/clients/test_google.py
@@ -44,7 +44,7 @@ def patch_is_google_token_valid(
         ]
     )
 
-    return is_google_token_valid("token", http, http2)
+    return is_google_token_valid("", http, http2)
 
 
 def test_is_google_token_valid_happy(monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
## Changes made
Env config variables moved into docker file.
AWS login secrets must still be transferred manually.
Other secrets are stores in AWS parameter store and bin/infra pull-env populates them into dev.env
bin/infra pull-env is automatically called during bin/dev pull

Additionally, google_dev_config is no longer necessary.

## Screencapture (if applicable)

## Testing
- [x] End-to-End