### PR TITLE
[feat] Move backend prod deploy to ECS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ client
 .git
 bin
 server/.venv
+**/*.env

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -34,26 +34,32 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Deploy in EC2
+
+      - name: Login to Public ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         env:
-          PRIVATE_KEY: ${{ secrets.EC2_PRIVATE_KEY  }}
-          HOSTNAME : ${{ secrets.EC2_HOSTNAME  }}
+          AWS_REGION: us-east-1
 
-        run: |
-          echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
-          ssh -o StrictHostKeyChecking=no -i private_key ubuntu@${HOSTNAME} '
+      - name: Build and push image
+        uses: docker/build-push-action@v2
+        with:
+          pull: true # pull new intermediate images
+          push: true # push to ECR
+          tags: public.ecr.aws/a5f0m6q3/syncm8_prod:latest
+          file: Dockerfile
+          target: prod # build the prod image
 
-            #Now we have got the access of EC2 and we will start the deploy .
-            cd /home/ubuntu/syncm8 &&
-            git checkout main &&
-            git fetch --all &&
-            git reset --hard origin/main &&
-            git pull origin main &&
-            cd server &&
-            source syncm8env/bin/activate &&
-            pipenv install --deploy &&
-            sudo systemctl restart syncm8.service
-          '
+      - name: Deploy to ECS
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-2
+
+        run: aws ecs update-service --force-new-deployment --service service --cluster backend-cluster
 
   frontend-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/devDockerBuild.yml
+++ b/.github/workflows/devDockerBuild.yml
@@ -37,4 +37,5 @@ jobs:
           pull: true # pull new intermediate images
           push: true # push to ECR
           tags: public.ecr.aws/a5f0m6q3/syncm8_dev:latest
-          file: Dockerfile_dev
+          file: Dockerfile
+          target: dev

--- a/server/syncm8.ini
+++ b/server/syncm8.ini
@@ -1,11 +1,10 @@
 [uwsgi]
+
+http = :5000
 module = server:app
-
 master = true
-processes = 2
+enable-threads = true
+processes = 4
 
-socket = syncm8.sock
-chmod-socket = 666
-vacuum = true
-
-die-on-term = true
+# if a process is stuck for more than 60 seconds, kill it
+harakiri = 60


### PR DESCRIPTION
## Changes made
Set up AWS ECS - more details will be available in aws infra doc on notion.

Create step 2 in the process below.

On push to main branch, gh actions triggers a workflow that:
1. Runs migration runner
2. Runs backend deploy
	a. Authenticate docker with aws to allow push to ecr
	b. Build the prod image
	c. Push the prod image
	d. Restart the ECS service to force it to grab the new image we just pushed
3. Runs frontend deploy
	a. Install deps
	b. Build image
	c. Sync s3 website deploy

## Screencapture (if applicable)

## Testing
- [x] End-to-End
Ran the backend-deploy job as a manual trigger on another branch. Confirmed working.
https://backend.syncm8.com is currently on prod docker image.

## Work left to be done
- remove ec2 specific secrets from github environment
- clean up aws permissions 
- `dev/prod` script for backup manual deploy 