### PR TITLE
[feat] Allow manual control for pushing to prod 

### DIFF
--- a/bin/infra
+++ b/bin/infra
@@ -74,6 +74,12 @@ pullEnv(){
     mv new.dev.env server/dev.env
 }
 
+
+runPrivileged(){
+    addAWSToEnv
+    eval $*
+}
+
 # Print help message
 printHelp(){
     echo "Usage:  bin/infra COMMAND
@@ -83,6 +89,7 @@ Command Runner for syncm8 infra commands.
 Commands:
   build       Build dev image.
   login       Authenticate docker with aws ecr.
+  priv        Run command with aws authentication enabled.
   pull        Pull image from aws ecr.
   pull-env    Pulls secrets from AWS Parameter Store
   push        Push dev image to aws ecr.
@@ -107,6 +114,9 @@ case $op in
         ;;
     push)
         dockerPush
+        ;;
+    priv)
+        runPrivileged $restArgs
         ;;
     *)
         printHelp

--- a/bin/pre-push
+++ b/bin/pre-push
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-bin/dev check
+if [ $SYNCM8_NO_VERIFY == true ]; then
+    echo "LINTER DISABLED - re-enable by setting SYNCM8_NO_VERIFY to false"
+else
+    bin/dev check
+fi

--- a/bin/prod
+++ b/bin/prod
@@ -1,0 +1,54 @@
+PROD_ECR_REPO="public.ecr.aws/a5f0m6q3/syncm8_prod"
+
+# Build prod image.
+dockerBuild(){
+    bin/util logAndRun "docker build --pull --rm --target prod -t $PROD_ECR_REPO ."
+}
+
+# Push prod image to aws ecr.
+dockerPush(){
+    read -p "Are you sure you want to push an image to PRODUCTION?????[y/n]"$'\n' ans
+    if [ $ans == "y" ]; then
+        bin/util logAndRun "docker push $PROD_ECR_REPO"
+    else
+        echo "Not pushing."
+    fi
+}
+
+# Restart AWS ECS service.
+awsDeploy(){
+    bin/infra priv "aws ecs update-service --force-new-deployment --service service --cluster backend-cluster | cat"
+}
+
+
+# Print help message
+printHelp(){
+    echo "Usage:  bin/infra COMMAND
+
+Command Runner for syncm8 infra commands.
+
+Commands:
+  build       Build prod image.
+  push        Push prod image to aws ecr.
+                  N.b. Must be authenticated with ecr.
+  deploy      Restart AWS ECS service. (pulls the latest docker image
+              from ECR. - must manually push the image.)"
+}
+
+op=$1
+restArgs="${@:2}"
+
+case $op in
+    build)
+        dockerBuild
+        ;;
+    push)
+        dockerPush
+        ;;
+    deploy)
+        awsDeploy
+        ;;
+    *)
+        printHelp
+        ;;
+esac


### PR DESCRIPTION
## Changes made
Add bin/prod for running prod deploy from cli - just in case github actions brick and we need a quick rollback.

Add env variable to temporarily disable linters.

## Screencapture (if applicable)

## Testing
- [ ] End-to-End

## Work left to be done