### PR TITLE
[fix] Allow mysql to work on arm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
 
   mysql:
     image: mysql:8.0.23
+    platform: linux/x86_64
     container_name: syncm8_mysql
     volumes:
       - mysql_data:/var/lib/mysql


### PR DESCRIPTION
## Changes made
The official mysql docker image does not currently support arm64. This prevents it from being run natively on m1 Macs.

As a stopgap solution, we can tell docker to use the x64 version and let Rosetta handle the translation to arm.

## Screencapture (if applicable)


## Testing
- [ ] End-to-End


## Work left to be done
