### PR TITLE
[fix] Absolute graphql location to fix dev/ci pytest differences

### DIFF
--- a/.github/workflows/backendCI.yml
+++ b/.github/workflows/backendCI.yml
@@ -12,17 +12,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
 
-      - name: Install Dependencies
+      - name:
         run: |
-          cd server
-          pip install pipenv
-          pipenv install --dev
-
-      - name: Run Backend Tests
-        run: |
-          cd server
-          pipenv run pytest tests
+          touch dev.env
+          bin/dev py-req
+          bin/dev run pytest
+# Our docker-compose.yml expects there to be a dev.env file. Since our testing environment doesn't actually
+# need any of the secrets stored there, we can simply create an empty file: `touch dev.env`

--- a/server/src/api.py
+++ b/server/src/api.py
@@ -66,7 +66,7 @@ def load_user(user_id: str) -> Optional[User]:
     return User.lookup_user(user_id)
 
 
-schema_path = "./schema.graphql"
+schema_path = "/home/worker/app/server/schema.graphql"
 type_defs = gql(load_schema_from_path(schema_path))
 schema = make_executable_schema(type_defs, oid_scalar, date_scalar, query, mutation)
 


### PR DESCRIPTION
## Changes made
In #108 the dockerfile was changed to use the `/home/worker/app` work directory instead of the previous '/home/worker/app/server` directory only during development. 

This caused the graphql import in `api.py` to fail since it was a relative import that assumed the app would be started from within the `server/` folder. 

The easy/simple fix is to replace the relative import with an absolute import. This, however fails in ci since ci does not use the docker images and rather runs directly on gh action runners.

Thus, in order to enact this solution, we have to migrate the backend ci action to use the devbox container.

Additionally we use the `bin/dev` commands instead of direct shell commands in order to reduce code duplication and drift between the dev environment and the ci environment.

## Screencapture (if applicable)


## Testing
- [ ] End-to-End


## Work left to be done
