### PR TITLE
[fix] Assign default value during pre-push

### DIFF
--- a/bin/pre-push
+++ b/bin/pre-push
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ $SYNCM8_NO_VERIFY == true ]; then
+if [ ${SYNCM8_NO_VERIFY:-false} == true ]; then
     echo "LINTER DISABLED - re-enable by setting SYNCM8_NO_VERIFY to false"
 else
     bin/dev check


### PR DESCRIPTION
## Changes made
If the `SYNCM8_NO_VERIFY` env variable is not set, bash complains that you can't use the `==` operator with a single argument. 

To fix this, we can assign a default value to the `SYNCM8_NO_VERIFY` variable.

## Screencapture (if applicable)


## Testing
- [ ] End-to-End


## Work left to be done
