### PR TITLE
[feat] Move pre-commit action to use bin/dev commands

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,15 +10,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - uses: actions/setup-node@v2
-      with:
-        node-version: 10.x
-    - name: Install Modules
-      run: |
-        cd client
-        npm ci
 
-    - uses: pre-commit/action@v2.0.3
+    - name: Run pre-commit
+      run: |
+        git fetch origin main ${{ github.event.pull_request.base.sha }}
+        bin/infra build
+        touch dev.env
+        bin/dev run pipenv run pip install pre-commit
+        bin/dev sudo pre-commit run --hook-stage push --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.sha }}
+# Our docker-compose.yml expects there to be a dev.env file. Since our testing environment doesn't actually
+# need any of the secrets stored there, we can simply create an empty file: `touch dev.env`
+
+# We need to run `bin/dev sudo pre-commit` because of the npm issue outlined in https://github.com/SyncM8/syncm8/pull/126
+# This is alleviated in local dev environment by the `Install pre-commit.` step in the `READEME.md`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ bin/dev py-req
 ```shell
 bin/dev client-req
 ```
-
+8.  Install pre-commit.
+``` shell
+bin/dev sudo pre-commit install-hooks
+sudo chown -R $(id -u):$(id -g) .pre-commit
+```
 ---
 ## Running the App
 

--- a/bin/dev
+++ b/bin/dev
@@ -81,7 +81,7 @@ runJstest(){
 # args: list of args to pass to pre-commit
 runPrecommit(){
     # if no cli args, run standard pre-push
-    if [ ! $* ]; then
+    if [ ! $1 ]; then
         args="run --hook-stage push --from-ref origin/main --to-ref HEAD"
     else
         args=$*


### PR DESCRIPTION
## Changes made
Change the pre-commit github action to use devbox container instead of running the commands directly on gh action runner. 

This is an extension to #115 that helps standardize our github actions and allows python upgrade in #69 to proceed more smoothly.

Pre-commit installs all dependencies by itself (pip and npm dependencies for each pre-commit hook). It however, runs into a npm root user error.
![image](https://user-images.githubusercontent.com/9906905/147390416-4beb05bc-fc9b-4ce2-8290-4aa101de82a8.png)

As a workaround, we run pre-commit as root. 

This is the same issue that @leedm98 ran into when setting up pre-commit, and I was able to consistently repro it by deleting the `.pre-commit` folder and trying to install from a clean workspace. Added the workaround as a setup step in the readme.

## Screencapture (if applicable)


This is a follow up for 

## Testing
- [ ] End-to-End


## Work left to be done
Figure out why pre-commit has npm root user issues, and fix configuration to avoid the use of super user permissions.