### PR TITLE
[fix] Solve oversight where backend ci relies on an unbuilt devbox image

### DIFF
--- a/.github/workflows/backendCI.yml
+++ b/.github/workflows/backendCI.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name:
         run: |
+          bin/infra build
           touch dev.env
           bin/dev py-req
           bin/dev run pytest


### PR DESCRIPTION
## Changes made
When the devbox version increases, the image is not pushed to AWS ECR until the pr is merged into main.

This means `backend ci` will always fail during devbox version increases. To alleviate this, the gh action can simply build the image and then use that image.

## Screencapture (if applicable)


## Testing
- [ ] End-to-End


## Work left to be done
