### PR TITLE
[feat] Add pre-commit check for secret files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,3 +93,10 @@ repos:
         args:
         -   "--req Dockerfile"
         -   "--lock DEVBOX_VERSION"
+-   repo: https://github.com/EpicPi/SecretFileHook
+    rev: v1.0.1
+    hooks:
+    -   id: secret-file
+        verbose: true
+        args:
+        -   "--secret dev.env"


### PR DESCRIPTION
## Changes made
Create a new pre-commit hook that checks whether the secret file is included in the commit. Checks against file name only so effectively the same as regex for **/<secret_file.name> against all diffed files.

## Screencapture (if applicable)



## Testing
- [x] End-to-End
Created a commit with a `server/dev.env` file included. Ran `bin/dev check`.
![image](https://user-images.githubusercontent.com/9906905/147393656-cb19032a-29fe-453e-a830-8c9036384ee7.png)

## Work left to be done
