### PR TITLE
[fix] Change grep -P to perl command

### DIFF
--- a/bin/infra
+++ b/bin/infra
@@ -66,7 +66,7 @@ pullEnv(){
     # acquire keys from aws parameter store
     for ac in ${EXTERNAL_KEYS[@]}; do
         ret=$(aws ssm get-parameter --name $ac)
-        value=$(echo $ret | grep -Po '"Value":.*?[^\\]",'| cut -d \" -f4)
+        value=$(echo $ret | perl -nle'print $& while m{"Value":.*?[^\\]",}g'| cut -d \" -f4)
         key=$(echo $ac| cut -d _ -f2-)
         echo $key=$value >> new.dev.env
     done


### PR DESCRIPTION
## Changes made
`-P` option doesn't work on macOS as it uses grep 2.3 vs 3.x
Change the command so that the functionality is the same using `perl` instead of `grep`.

## Screencapture (if applicable)
before and after
![image](https://user-images.githubusercontent.com/12789302/147400704-ffbbbe1d-e295-46d9-8017-7b761a236f66.png)


## Testing
- [x] End-to-End


## Work left to be done
